### PR TITLE
Add RoArm M2 example scripts

### DIFF
--- a/examples/roarm/evaluate.py
+++ b/examples/roarm/evaluate.py
@@ -1,0 +1,29 @@
+from lerobot.common.datasets.utils import build_dataset_frame, hw_to_dataset_features
+from lerobot.common.policies.act.modeling_act import ACTPolicy
+from lerobot.common.robots.roarm_m2_follower import RoArmM2Follower, RoArmM2FollowerConfig
+from lerobot.common.utils.control_utils import predict_action
+from lerobot.common.utils.utils import get_safe_torch_device
+
+robot_config = RoArmM2FollowerConfig(port="/dev/ttyUSB1")
+robot = RoArmM2Follower(robot_config)
+
+robot.connect()
+
+policy = ACTPolicy.from_pretrained("user/act_roarm")
+policy.reset()
+
+obs_features = hw_to_dataset_features(robot.observation_features, "observation")
+
+print("Running inference")
+while True:
+    obs = robot.get_observation()
+    observation_frame = build_dataset_frame(obs_features, obs, prefix="observation")
+    action_values = predict_action(
+        observation_frame,
+        policy,
+        get_safe_torch_device(policy.config.device),
+        policy.config.use_amp,
+    )
+    action = {name: action_values[i].item() for i, name in enumerate(robot.action_features)}
+    robot.send_action(action)
+

--- a/examples/roarm/record.py
+++ b/examples/roarm/record.py
@@ -1,0 +1,47 @@
+import time
+
+from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.common.datasets.utils import hw_to_dataset_features
+from lerobot.common.robots.roarm_m2_follower import RoArmM2Follower, RoArmM2FollowerConfig
+from lerobot.common.teleoperators.roarm_m2_leader import RoArmM2Leader, RoArmM2LeaderConfig
+
+NB_STEPS = 250
+
+robot_config = RoArmM2FollowerConfig(port="/dev/ttyUSB1")
+teleop_config = RoArmM2LeaderConfig(port="/dev/ttyUSB0")
+
+robot = RoArmM2Follower(robot_config)
+teleop = RoArmM2Leader(teleop_config)
+
+action_features = hw_to_dataset_features(robot.action_features, "action")
+obs_features = hw_to_dataset_features(robot.observation_features, "observation")
+dataset_features = {**action_features, **obs_features}
+
+dataset = LeRobotDataset.create(
+    repo_id="user/roarm" + str(int(time.time())),
+    fps=10,
+    features=dataset_features,
+    robot_type=robot.name,
+)
+
+teleop.connect()
+robot.connect()
+
+if not teleop.is_connected or not robot.is_connected:
+    exit()
+
+print("Starting RoArm teleoperation recording")
+for _ in range(NB_STEPS):
+    action = teleop.get_action()
+    sent = robot.send_action(action)
+    obs = robot.get_observation()
+    dataset.add_frame({**sent, **obs}, "RoArm dataset example")
+
+print("Disconnecting devices")
+teleop.disconnect()
+robot.disconnect()
+
+print("Uploading dataset to the hub")
+dataset.save_episode()
+dataset.push_to_hub()
+

--- a/examples/roarm/replay.py
+++ b/examples/roarm/replay.py
@@ -1,0 +1,23 @@
+import time
+
+from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.common.robots.roarm_m2_follower import RoArmM2Follower, RoArmM2FollowerConfig
+from lerobot.common.utils.robot_utils import busy_wait
+
+robot_config = RoArmM2FollowerConfig(port="/dev/ttyUSB1")
+robot = RoArmM2Follower(robot_config)
+
+dataset = LeRobotDataset("user/roarm_example", episodes=[0])
+
+robot.connect()
+
+print("Replaying episode…")
+for action_array in dataset.hf_dataset["action"]:
+    t0 = time.perf_counter()
+    action = {name: float(action_array[i]) for i, name in enumerate(dataset.features["action"]["names"])}
+    robot.send_action(action)
+    busy_wait(max(1.0 / dataset.fps - (time.perf_counter() - t0), 0.0))
+
+print("Disconnecting robot")
+robot.disconnect()
+

--- a/examples/roarm/teleoperate.py
+++ b/examples/roarm/teleoperate.py
@@ -1,0 +1,21 @@
+from lerobot.common.robots.roarm_m2_follower import RoArmM2Follower, RoArmM2FollowerConfig
+from lerobot.common.teleoperators.roarm_m2_leader import RoArmM2Leader, RoArmM2LeaderConfig
+
+robot_config = RoArmM2FollowerConfig(port="/dev/ttyUSB1")
+teleop_config = RoArmM2LeaderConfig(port="/dev/ttyUSB0")
+
+robot = RoArmM2Follower(robot_config)
+teleop = RoArmM2Leader(teleop_config)
+
+robot.connect()
+teleop.connect()
+
+try:
+    while True:
+        action = teleop.get_action()
+        robot.send_action(action)
+except KeyboardInterrupt:
+    pass
+finally:
+    teleop.disconnect()
+    robot.disconnect()

--- a/lerobot/common/robots/roarm_m2_follower/__init__.py
+++ b/lerobot/common/robots/roarm_m2_follower/__init__.py
@@ -1,0 +1,4 @@
+from .config_roarm_m2_follower import RoArmM2FollowerConfig
+from .roarm_m2_follower import RoArmM2Follower
+
+__all__ = ["RoArmM2FollowerConfig", "RoArmM2Follower"]

--- a/lerobot/common/robots/roarm_m2_follower/config_roarm_m2_follower.py
+++ b/lerobot/common/robots/roarm_m2_follower/config_roarm_m2_follower.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+
+from lerobot.common.cameras import CameraConfig
+from ..config import RobotConfig
+
+
+@RobotConfig.register_subclass("roarm_m2_follower")
+@dataclass
+class RoArmM2FollowerConfig(RobotConfig):
+    port: str
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/lerobot/common/robots/roarm_m2_follower/roarm_m2_follower.py
+++ b/lerobot/common/robots/roarm_m2_follower/roarm_m2_follower.py
@@ -1,0 +1,131 @@
+import json
+import logging
+import time
+from functools import cached_property
+from typing import Any
+
+import serial
+
+from lerobot.common.cameras.utils import make_cameras_from_configs
+from lerobot.common.constants import OBS_STATE
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+
+from ..robot import Robot
+from .config_roarm_m2_follower import RoArmM2FollowerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RoArmM2Follower(Robot):
+    config_class = RoArmM2FollowerConfig
+    name = "roarm_m2_follower"
+
+    def __init__(self, config: RoArmM2FollowerConfig):
+        super().__init__(config)
+        self.config = config
+        self.ser: serial.Serial | None = None
+        self.cameras = make_cameras_from_configs(config.cameras)
+        self.motor_names = ["base", "shoulder", "elbow", "hand"]
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{m}.pos": float for m in self.motor_names}
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {
+            cam: (
+                self.config.cameras[cam].height,
+                self.config.cameras[cam].width,
+                3,
+            )
+            for cam in self.cameras
+        }
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self.ser is not None and self.ser.is_open and all(cam.is_connected for cam in self.cameras.values())
+
+    def connect(self, calibrate: bool = True) -> None:
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self} already connected")
+        self.ser = serial.Serial(self.config.port, 115200, timeout=1.0, dsrdtr=None)
+        self.ser.setRTS(False)
+        self.ser.setDTR(False)
+        for cam in self.cameras.values():
+            cam.connect()
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def calibrate(self) -> None:
+        pass
+
+    def configure(self) -> None:
+        pass
+
+    def _send_cmd(self, payload: dict) -> None:
+        assert self.ser is not None
+        self.ser.write((json.dumps(payload) + "\n").encode("utf-8"))
+        self.ser.flush()
+
+    def _read_feedback(self, timeout: float) -> dict | None:
+        assert self.ser is not None
+        end = time.time() + timeout
+        while time.time() < end:
+            line = self.ser.readline().decode(errors="ignore").strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("T") == 1051:
+                return data
+        return None
+
+    def get_observation(self) -> dict[str, Any]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        self._send_cmd({"T": 105})
+        fb = self._read_feedback(timeout=0.1) or {}
+        angles = [float(fb.get(k[0], 0.0)) for k in self.motor_names]
+        obs = {f"{m}.pos": a for m, a in zip(self.motor_names, angles)}
+        for cam_key, cam in self.cameras.items():
+            obs[cam_key] = cam.async_read()
+        return obs
+
+    def send_action(self, action: dict[str, float]) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        angles = {m: action.get(f"{m}.pos", 0.0) for m in self.motor_names}
+        cmd = {
+            "T": 102,
+            "base": angles["base"],
+            "shoulder": angles["shoulder"],
+            "elbow": angles["elbow"],
+            "hand": angles["hand"],
+            "spd": 0.6,
+            "acc": 10,
+        }
+        self._send_cmd(cmd)
+        return {f"{m}.pos": angles[m] for m in self.motor_names}
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        assert self.ser is not None
+        self.ser.close()
+        for cam in self.cameras.values():
+            cam.disconnect()
+        logger.info(f"{self} disconnected.")

--- a/lerobot/common/robots/utils.py
+++ b/lerobot/common/robots/utils.py
@@ -45,6 +45,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from .viperx import ViperX
 
         return ViperX(config)
+    elif config.type == "roarm_m2_follower":
+        from .roarm_m2_follower import RoArmM2Follower
+
+        return RoArmM2Follower(config)
     elif config.type == "mock_robot":
         from tests.mocks.mock_robot import MockRobot
 

--- a/lerobot/common/teleoperators/roarm_m2_leader/__init__.py
+++ b/lerobot/common/teleoperators/roarm_m2_leader/__init__.py
@@ -1,0 +1,4 @@
+from .config_roarm_m2_leader import RoArmM2LeaderConfig
+from .roarm_m2_leader import RoArmM2Leader
+
+__all__ = ["RoArmM2LeaderConfig", "RoArmM2Leader"]

--- a/lerobot/common/teleoperators/roarm_m2_leader/config_roarm_m2_leader.py
+++ b/lerobot/common/teleoperators/roarm_m2_leader/config_roarm_m2_leader.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+from ..config import TeleoperatorConfig
+
+
+@TeleoperatorConfig.register_subclass("roarm_m2_leader")
+@dataclass
+class RoArmM2LeaderConfig(TeleoperatorConfig):
+    port: str

--- a/lerobot/common/teleoperators/roarm_m2_leader/roarm_m2_leader.py
+++ b/lerobot/common/teleoperators/roarm_m2_leader/roarm_m2_leader.py
@@ -1,0 +1,91 @@
+import json
+import logging
+import time
+from typing import Any
+
+import serial
+
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from ..teleoperator import Teleoperator
+from .config_roarm_m2_leader import RoArmM2LeaderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RoArmM2Leader(Teleoperator):
+    config_class = RoArmM2LeaderConfig
+    name = "roarm_m2_leader"
+
+    def __init__(self, config: RoArmM2LeaderConfig):
+        super().__init__(config)
+        self.config = config
+        self.ser: serial.Serial | None = None
+        self.motor_names = ["base", "shoulder", "elbow", "hand"]
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {f"{m}.pos": float for m in self.motor_names}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.ser is not None and self.ser.is_open
+
+    def connect(self, calibrate: bool = True) -> None:
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self} already connected")
+        self.ser = serial.Serial(self.config.port, 115200, timeout=1.0, dsrdtr=None)
+        self.ser.setRTS(False)
+        self.ser.setDTR(False)
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def calibrate(self) -> None:
+        pass
+
+    def configure(self) -> None:
+        pass
+
+    def _send_cmd(self, payload: dict) -> None:
+        assert self.ser is not None
+        self.ser.write((json.dumps(payload) + "\n").encode("utf-8"))
+        self.ser.flush()
+
+    def _read_feedback(self, timeout: float) -> dict | None:
+        assert self.ser is not None
+        end = time.time() + timeout
+        while time.time() < end:
+            line = self.ser.readline().decode(errors="ignore").strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if data.get("T") == 1051:
+                return data
+        return None
+
+    def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        self._send_cmd({"T": 105})
+        fb = self._read_feedback(timeout=0.1) or {}
+        angles = [float(fb.get(k[0], 0.0)) for k in self.motor_names]
+        return {f"{m}.pos": a for m, a in zip(self.motor_names, angles)}
+
+    def send_feedback(self, feedback: dict[str, Any]) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        assert self.ser is not None
+        self.ser.close()
+        logger.info(f"{self} disconnected.")

--- a/lerobot/common/teleoperators/utils.py
+++ b/lerobot/common/teleoperators/utils.py
@@ -41,6 +41,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> Teleoperator:
         from .widowx import WidowX
 
         return WidowX(config)
+    elif config.type == "roarm_m2_leader":
+        from .roarm_m2_leader import RoArmM2Leader
+
+        return RoArmM2Leader(config)
     elif config.type == "mock_teleop":
         from tests.mocks.mock_teleop import MockTeleop
 


### PR DESCRIPTION
## Summary
- add example scripts for RoArm M2 teleoperation, recording, evaluation and replay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'termcolor')*

------
https://chatgpt.com/codex/tasks/task_e_68432ea10360832aa3be4555938ed67b